### PR TITLE
Added canonical_urls to articles

### DIFF
--- a/2022-07-12-Wilcots.md
+++ b/2022-07-12-Wilcots.md
@@ -10,7 +10,7 @@ publish_on:
   
 type: user
 
-canonical_url: 
+canonical_url: https://htcondor.org/featured-users/2022-07-12-Wilcots.html
 
 image:
   path: "https://raw.githubusercontent.com/CHTC/Articles/main/images/Wilcots-card.png"

--- a/2022-07-21-Messick.md
+++ b/2022-07-21-Messick.md
@@ -11,7 +11,7 @@ publish_on:
   
 type: user
 
-canonical_url: 
+canonical_url: https://htcondor.org/featured-users/2022-07-21-Messick.html
 
 image:
   path: "https://raw.githubusercontent.com/CHTC/Articles/main/images/Messick-card.png"

--- a/2022-09-09-NIAID-ACE-students-attend-OSG-User-School.md
+++ b/2022-09-09-NIAID-ACE-students-attend-OSG-User-School.md
@@ -9,7 +9,7 @@ publish_on:
 
 type: news
 
-canonical_url: 
+canonical_url: https://osg-htc.org/spotlights/NIAID-ACE-students-attend-OSG-User-School.html
 
 image:
     path: "https://raw.githubusercontent.com/CHTC/Articles/main/images/NIAID_students.jpeg"

--- a/2022-10-03-Joe-B-Profile.md
+++ b/2022-10-03-Joe-B-Profile.md
@@ -8,7 +8,7 @@ publish_on:
 
 type: news
 
-canonical_url: 
+canonical_url: https://chtc.cs.wisc.edu/Joe-B-Profile.html
 
 image:
 path: "https://raw.githubusercontent.com/CHTC/Articles/main/images/joes-cat.jpg"

--- a/2022-11-03-ucsd-external-release.md
+++ b/2022-11-03-ucsd-external-release.md
@@ -11,7 +11,7 @@ publish_on:
 
 type: news
 
-canonical_url: 
+canonical_url: https://osg-htc.org/spotlights/ucsd-external-release.html
 
 image:
     path: "https://raw.githubusercontent.com/CHTC/Articles/main/images/ucsd-public-relations.png"

--- a/2022-12-14-CHTC-Facilitation.md
+++ b/2022-12-14-CHTC-Facilitation.md
@@ -14,7 +14,7 @@ tag:
 
 type: news
 
-canonical_url:
+canonical_url: https://chtc.cs.wisc.edu/CHTC-Facilitation.html
 
 image:
     path: "https://raw.githubusercontent.com/CHTC/Articles/main/images/Facilitation-cover.jpeg"

--- a/2023-01-23-get-to-know-todd.md
+++ b/2023-01-23-get-to-know-todd.md
@@ -11,7 +11,7 @@ publish_on:
 
 type: news
 
-canonical_url: 
+canonical_url: https://osg-htc.org/spotlights/get-to-know-todd.html
 image:
   path: https://raw.githubusercontent.com/CHTC/Articles/main/images/todd-t-article-0.jpg
   alt: Image of Todd T taking a selfie with a tropical beach in the background.

--- a/2023-03-01-Google-HTCondor.md
+++ b/2023-03-01-Google-HTCondor.md
@@ -10,7 +10,7 @@ publish_on:
 
 type: user
 
-canonical_url: 
+canonical_url: https://www.chtc.cs.wisc.edu/Google-HTCondor.html
 
 image:
     path: "https://raw.githubusercontent.com/CHTC/Articles/main/images/google-qvm.jpg"

--- a/2023-04-24-ASP.md
+++ b/2023-04-24-ASP.md
@@ -11,7 +11,7 @@ publish_on:
 
 type: user
 
-canonical_url: 
+canonical_url: https://htcondor.org/featured-users/2023-04-24-ASP.html
 
 image:
     path: "https://raw.githubusercontent.com/CHTC/Articles/main/images/asp-banner.jpeg"

--- a/2023-04-24-CHTC-Philosophy.md
+++ b/2023-04-24-CHTC-Philosophy.md
@@ -11,7 +11,7 @@ publish_on:
 
 type: news
 
-canonical_url: 
+canonical_url: https://chtc.cs.wisc.edu/CHTC-Philosophy.html
 
 image:
     path: "https://raw.githubusercontent.com/CHTC/Articles/main/images/chtc-philosophy-server.jpg"

--- a/2023-04-25-ospool-computation.md
+++ b/2023-04-25-ospool-computation.md
@@ -11,7 +11,7 @@ publish_on:
 
 type: user
 
-canonical_url: 
+canonical_url: https://htcondor.org/featured-users/2023-04-25-ospool-computation.html
 image:
   path: https://raw.githubusercontent.com/CHTC/Articles/main/images/ospool-comp.jpg
   alt: Microscope beside computer by Tima Miroshnichenko from Pexels.

--- a/2023-05-23-HTCondor-Week-Europe-2023.md
+++ b/2023-05-23-HTCondor-Week-Europe-2023.md
@@ -7,7 +7,7 @@ publish_on:
   
 type: news 
 
-canonical_url: 
+canonical_url: https://htcondor.org/news/htcondor-european-workshop-2023/
 
 image: 
   path: https://raw.githubusercontent.com/CHTC/Articles/main/images/european-htcondor-week-2023.png

--- a/2023-06-12-htcondor-helps-enable-mars-research.md
+++ b/2023-06-12-htcondor-helps-enable-mars-research.md
@@ -10,7 +10,7 @@ publish_on:
   
 type: user
 
-canonical_url: 
+canonical_url: https://htcondor.org/featured-users/2023-06-12-htcondor-helps-enable-mars-research.html
 
 tag:
 - chtc_featured_article


### PR DESCRIPTION
Article PR Template

Article previews can be found [here](https://chtc.github.io/article-preview/)

* [ ] Linked the preview url `https://chtc.github.io/article-preview/<article-url>`
* [ ] Looked at the link in https://socialsharepreview.com/ to verify socials
* [ ] Requested reviews from the correct parties
